### PR TITLE
[PROF-11306] Fix crashtracking specs failing due to format change

### DIFF
--- a/spec/records_spec.rb
+++ b/spec/records_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe "Records" do
 
       message = JSON.parse(payload[:message], symbolize_names: true)
       expect(message).to a_hash_including(
-        :additional_stacktraces,
         :files,
         metadata: a_hash_including(
           :tags,


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the crashtracking specs failing on
https://github.com/Datadog/vaccine/actions/runs/13239150949 (from https://github.com/DataDog/dd-trace-rb/pull/4353 ) due to the `additional_stacktraces` key no longer being included in the payload.

Since I removed the assertion on the key, the updated test will work on both libdatadog < v16 as well as >= v16.

**Motivation:**

Unblock upgrade to libdatadog v16.

**Additional Notes:**

To get the "records", I needed to

1. Clone catadog, bundle install
2. mkdir records
3. bundle exec bin/catadog --record records --no-forward

...and then `kill -SEGV` a Ruby process that had dd-trace-rb loaded.

This was enough for me:

```bash
DD_TRACE_AGENT_PORT=8128 be ruby -e "require 'datadog'; Datadog.configure { }; sleep"
```

**How to test the change?**

I've gathered the records from both libdatadog < v16 and v16 in https://gist.github.com/ivoanjo/52314e67602f2039bdcfe4ab869701b2 and used them to validate this change.

By placing them into a directory, they can be validated as such:

```bash
RECORDS_DIR=records-new/ bundle exec rspec spec/records_spec.rb
```