### PR TITLE
Faster Ruby 1.8 testing

### DIFF
--- a/src/ruby/1.8/Dockerfile
+++ b/src/ruby/1.8/Dockerfile
@@ -1,11 +1,19 @@
 FROM ghcr.io/datadog/images-rb/engines/ruby:1.8-centos-gcc
 
-RUN gem install rack -v 1.6.13
-RUN gem install tilt -v 2.0.11
-RUN gem install sinatra -v '~> 1.0'
-RUN gem install json -v 1.8.6
+WORKDIR /app
 
-COPY <<RUBY /app/hello.rb
+COPY <<RUBY Gemfile
+source 'https://rubygems.org'
+
+gem 'rack', '1.6.13'
+gem 'tilt', '2.0.11'
+gem 'sinatra', '~> 1.0'
+gem 'json', '1.8.6'
+RUBY
+
+RUN bundle install
+
+COPY <<RUBY hello.rb
 require 'rubygems'
 require 'sinatra/base'
 require 'json'
@@ -21,8 +29,6 @@ end
 Rack::Server.new(:app => App, :Host => '0.0.0.0', :Port => 3000).start
 RUBY
 
-WORKDIR /app
-
 ENTRYPOINT ["/bin/bash", "-c"]
 
-CMD ["ruby hello.rb" ]
+CMD ["bundle exec ruby hello.rb" ]


### PR DESCRIPTION
`gem install`s in Ruby 1.8 are taking 2 minutes each, making the 1.8 job take over 10 minutes, while all other variants run in about 2-3 minutes: https://github.com/DataDog/vaccine/actions/runs/13242124533/job/36959676928#step:9:76 
![Screenshot 2025-02-10 at 1 05 31 PM](https://github.com/user-attachments/assets/0042d178-e98e-4137-b9a3-931a9cf6af96)

This PR uses bundler to install the necessary gems instead, dropping the gem installation time to 3 seconds total: https://github.com/DataDog/vaccine/actions/runs/13250285204/job/36986409566?pr=15#step:9:97

I tried to make `gem install` faster, but all normal techniques (`--no-document`) yielded no improvements. Interestingly, a `gem install` where the gem is already installed still takes minutes to run.

This can be extended to up to Ruby 2.2, if this approach is well received, but the total CI time won't diminish since the more complex runs (the full Rails runs on newer rubies) are now the bottleneck.
