### PR TITLE
Fix cross-repo race condition

### DIFF
--- a/.github/workflows/vaccine.yml
+++ b/.github/workflows/vaccine.yml
@@ -6,10 +6,12 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
-      commit_sha:
-        description: 'Commit SHA'
+      dd-lib-ruby-init-tag:
+        description: 'dd-lib-ruby-init image tag'
         required: true
         default: 'latest_snapshot'
+
+run-name: "dd-lib-ruby-init:${{ inputs.dd-lib-ruby-init-tag || 'latest_snapshot' }}"
 
 jobs:
   inoculate:
@@ -102,7 +104,7 @@ jobs:
           docker create \
             --name init \
             -v vaccine:/datadog-init/package \
-            ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:${{ inputs.commit_sha || 'latest_snapshot' }}
+            ghcr.io/datadog/dd-trace-rb/dd-lib-ruby-init:${{ inputs.dd-lib-ruby-init-tag || 'latest_snapshot' }}
       - run: |
           docker build \
             --tag patient:${{ matrix.engine.name }}-${{ matrix.engine.version }} \

--- a/.github/workflows/vaccine.yml
+++ b/.github/workflows/vaccine.yml
@@ -10,8 +10,12 @@ on:
         description: 'dd-lib-ruby-init image tag'
         required: true
         default: 'latest_snapshot'
+      glci-pipeline-id:
+        description: 'GitLab CI pipeline ID'
+        required: false
+        default: ''
 
-run-name: "dd-lib-ruby-init:${{ inputs.dd-lib-ruby-init-tag || 'latest_snapshot' }}"
+run-name: "dd-lib-ruby-init:${{ inputs.dd-lib-ruby-init-tag || 'latest_snapshot' }} ${{ inputs.glci-pipeline-id == '' && 'manual' || format('glci:{0}', inputs.glci-pipeline-id) }}"
 
 jobs:
   inoculate:

--- a/.github/workflows/vaccine.yml
+++ b/.github/workflows/vaccine.yml
@@ -10,12 +10,12 @@ on:
         description: 'dd-lib-ruby-init image tag'
         required: true
         default: 'latest_snapshot'
-      glci-pipeline-id:
-        description: 'GitLab CI pipeline ID'
+      trigger-id:
+        description: 'Trigger ID'
         required: false
         default: ''
 
-run-name: "dd-lib-ruby-init:${{ inputs.dd-lib-ruby-init-tag || 'latest_snapshot' }} ${{ inputs.glci-pipeline-id == '' && 'manual' || format('glci:{0}', inputs.glci-pipeline-id) }}"
+run-name: "dd-lib-ruby-init:${{ inputs.dd-lib-ruby-init-tag || 'latest_snapshot' }}${{ inputs.trigger-id && format(' {0}', inputs.trigger-id) }}"
 
 jobs:
   inoculate:


### PR DESCRIPTION
Given that we run across repos and across CIs, there was a significant probability to pick incorrect workflows, that would be entirely unrelated to the `dd-trace-rb` item that triggered a workflow here.

On this side this is addressed by:

- allowing an additional `trigger-id` input
- reflecting that `trigger-id` in the workflow run name

As a bonus this allows direct identification of workflow runs straight from GitHub Actions UI.

On the `dd-trace-rb` side it then becomes possible to select the workflow by run name and properly identify it with absolute certainty.

The image is pulled by tag containing only the commit SHA and so remains vulnerable to race conditions.

Sister PR: https://github.com/DataDog/dd-trace-rb/pull/4404