### PR TITLE
Add policy

### DIFF
--- a/.github/chainguard/dd-trace-rb.dispatch.sts.yaml
+++ b/.github/chainguard/dd-trace-rb.dispatch.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://gitlab.ddbuild.io
+
+subject: repo:DataDog/dd-trace-rb:ref:refs/heads/*
+
+claim_pattern:
+  project_path: "DataDog/dd-trace-rb"
+
+permissions:
+  contents: read


### PR DESCRIPTION
Adding policy is required for secure token service. 